### PR TITLE
Only wait until shutdown in shutdown in Runner.

### DIFF
--- a/src/main/resources/meetup-scala/server/Runner.mustache
+++ b/src/main/resources/meetup-scala/server/Runner.mustache
@@ -32,6 +32,8 @@ trait Runner {
       System.in.read()
       doShutdownServer()
       doShutdownService()
+      /* Block the main thread to prevent exit until the server has shutdown. */
+      server.waitTillShutdown()
     } else {
       /* Not running under SBT, or we are but under a forked JVM. In either
          case we ensure shutdown but registering our shutdown procedure as a
@@ -39,10 +41,9 @@ trait Runner {
       sys.addShutdownHook {
         doShutdownServer()
         doShutdownService()
+        server.waitTillShutdown()        
       }
     }
 
-    /* Block the main thread to prevent exit until the server has shutdown. */
-    server.waitTillShutdown()
   }
 }


### PR DESCRIPTION
As written, we can't use the Runner in the test context because it holds on
to the main thread.