### PR TITLE
Request log should be one line.

### DIFF
--- a/src/main/resources/meetup-scala/server/RequestLoggingHandler.mustache
+++ b/src/main/resources/meetup-scala/server/RequestLoggingHandler.mustache
@@ -29,10 +29,6 @@ class RequestLoggingHandler(handler: RequestHandler[ByteBuf, ByteBuf]) extends R
         case addr => s"unknown socket address type: $addr"
       }
 
-    s"""
-       |Request from $remoteAddress
-       |${request.getHttpVersion} ${request.getHttpMethod} ${request.getUri}
-       |$headers
-     """.stripMargin
+    s"""Request from $remoteAddress ${request.getHttpVersion} ${request.getHttpMethod} ${request.getUri} $headers"""
   }
 }


### PR DESCRIPTION
The multi-line logging is a problem, especially for stackdriver (who stores and expects one-line log messages for us).