### PR TITLE
When writing a response, use the amount of bites, not the amount of characters to calculate buffer size and header 

### DIFF
--- a/src/main/resources/meetup-scala/server/apiRouter.mustache
+++ b/src/main/resources/meetup-scala/server/apiRouter.mustache
@@ -80,10 +80,10 @@ class {{classname}}Router(api: {{classname}}) extends Router(api) {
          response.setStatus(HttpResponseStatus.OK)
          val content: ByteBuf =
              response.getAllocator
-             .buffer(message.length)
+             .buffer(message.getBytes.length)
              .writeBytes(message.getBytes)
          val headers = response.getHeaders
-         headers.set(HttpHeaderNames.CONTENT_LENGTH, message.length)
+         headers.set(HttpHeaderNames.CONTENT_LENGTH, message.getBytes.length)
          headers.set(HttpHeaderNames.CONTENT_TYPE, "application/json")
          response.write(content)
          response.close(true)


### PR DESCRIPTION
I tested this by making the changes in my trnaround project manually, seemed to resolve the issue I was seeing with cut off messages.