### PR TITLE
Allow overriding of okhttpclient

### DIFF
--- a/src/main/resources/meetup-scala/client/ApiInvoker.mustache
+++ b/src/main/resources/meetup-scala/client/ApiInvoker.mustache
@@ -112,5 +112,5 @@ object ApiInvoker {
   }
 
   def get(okHttp: OkHttpClient = defaultOkkHttp): ApiInvoker =
-    new ApiInvoker(defaultOkkHttp)
+    new ApiInvoker(okHttp)
 }


### PR DESCRIPTION
Seems like it was supposed to work the way that i'm changing it to.
Background: I have a usecase of the client where I need to override the default timeout values for the okhttpclient.  I was trying to create an ApiInvoker instance with my custom client, and it was not working, because it can only ever use the default.