### PR TITLE
Added importMapping for LocalDate to use the java.time package

### DIFF
--- a/src/main/java/com/meetup/codegen/BaseScalaCodegen.java
+++ b/src/main/java/com/meetup/codegen/BaseScalaCodegen.java
@@ -90,6 +90,8 @@ abstract class BaseScalaCodegen extends DefaultCodegen implements CodegenConfig 
         importMapping.put("ZonedDateTime", "java.time.ZonedDateTime");
 
         typeMapping.put("date", "LocalDate");
+        importMapping.put("LocalDate", "java.time.LocalDate");
+
         typeMapping.put("DateTime", "ZonedDateTime");
 
         typeMapping.put("int", "Int");

--- a/src/test/scala/com/meetup/codegen/MappedSwaggerDatePropertiesTest.scala
+++ b/src/test/scala/com/meetup/codegen/MappedSwaggerDatePropertiesTest.scala
@@ -24,7 +24,8 @@ class MappedSwaggerDatePropertiesTest extends FunSpec with Matchers {
 
   describe("the LocalDate type") {
     it("should map to the import java.time.LocalDate") {
-      assert(codeGen.importMapping().get("LocalDate") == "java.time.LocalDate")
+      //assert(codeGen.importMapping().get("LocalDate") == "java.time.LocalDate")
+      codeGen.importMapping().get("LocalDate") shouldBe "java.time.LocalDate"
     }
   }
 }

--- a/src/test/scala/com/meetup/codegen/MappedSwaggerDatePropertiesTest.scala
+++ b/src/test/scala/com/meetup/codegen/MappedSwaggerDatePropertiesTest.scala
@@ -20,9 +20,11 @@ class MappedSwaggerDatePropertiesTest extends FunSpec with Matchers {
           codeGen.getSwaggerType(f(from)) shouldBe to
       }
     }
-    it("should map LocalDate type to the import java.time.LocalDate") {
+  }
+
+  describe("the LocalDate type") {
+    it("should map to the import java.time.LocalDate") {
       assert(codeGen.importMapping().get("LocalDate") == "java.time.LocalDate")
     }
   }
-
 }

--- a/src/test/scala/com/meetup/codegen/MappedSwaggerDatePropertiesTest.scala
+++ b/src/test/scala/com/meetup/codegen/MappedSwaggerDatePropertiesTest.scala
@@ -20,6 +20,9 @@ class MappedSwaggerDatePropertiesTest extends FunSpec with Matchers {
           codeGen.getSwaggerType(f(from)) shouldBe to
       }
     }
+    it("should map LocalDate type to the import java.time.LocalDate") {
+      assert(codeGen.importMapping().get("LocalDate") == "java.time.LocalDate")
+    }
   }
 
 }


### PR DESCRIPTION
The issue this PR fixes:
Open API defines date to be a RFC3339 full-date. However, our generator emits a LocalDate type with a java import of import org.joda.time.*.