### PR TITLE
Added ability to override the server port via environment variable

### DIFF
--- a/src/main/resources/meetup-scala/server/Runner.mustache
+++ b/src/main/resources/meetup-scala/server/Runner.mustache
@@ -35,7 +35,9 @@ trait Runner {
 
     val (service, doShutdownService) = initializeService(sys.env, args)
     setInitialReadiness()
-    val (server, doShutdownServer) = Server(9000, service)
+
+    val port = sys.env.get("SERVER_PORT").map(_.toInt).getOrElse(9000)
+    val (server, doShutdownServer) = Server(port, service)
 
     if (Thread.currentThread().getName.startsWith("run-main-")) {
       /* We're running under SBT so stay attached to the terminal and shutdown


### PR DESCRIPTION
In our daily work we sometimes need to bring up multiple microservices on the same machine in order to test interaction between them. `meetup-scala-generator` hard codes the server port to 9000 with no ability to override it externally, which results in multiple services competing for the same port. Currently we solve this by updating the port number in generated sources. However such changes do not survive rebuilding the application, so we have to change the port every time after running `sbt clean package`. 

This PR modifies the template for `Runner` class to first try reading the port number from `SERVER_PORT` environment variable, and if it's missing fall back to the default 9000 port.

**How did I test this PR**:
I made sure the `meetup-scala-generator` builds successfully and that all tests pass. I tested the line that parses the port number by updating the generated sources of one of our microservices and then running that microservice both with and without `SERVER_PORT` env variable set. I made sure that if the environment variable is not set, the server starts on default port 9000, and if the environment variable is set to other port number, it gets picked up by the server.